### PR TITLE
Remove Etherscan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ as it is still possible the original one will go through.
 ### Pending transactions discovery
 
 _Plunger_ discovers pending transactions by looking for them in the Parity transaction queue.
-Bear in mind that it is a custom _Parity_ RPC endpoint and so this latter method will not
+Bear in mind that it is a custom _Parity_ RPC endpoint and so this method will not
 work with _geth_.
 
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ seth send --async --gas-price=500000000 --value=1 -F $ETH_FROM $ETH_FROM
 bin/plunger --override-with-zero-txs $ETH_FROM
 ```
 
-The above snippet uses `seth` (see <https://github.com/dapphub/seth>) for sending transactions.
+The above snippet uses `seth` (see <https://github.com/dapphub/dapptools/tree/master/src/seth>) for sending transactions.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to list pending transactions for manual inspection.
 _plunger_ has been created during development of the Maker Keeper Framework.
 It is essential to run each keeper from an individual address that does not
 have any pending transactions. That is why before starting each keeper, doing
-a `plunger --source parity_txqueue --wait 0x.....` is recommended.
+a `plunger --wait 0x.....` is recommended.
 
 If you want to discuss this tool, the best place is the _#keeper_ channel
 in the Maker RocketChat, linked above.
@@ -56,7 +56,7 @@ export LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openss
 
 ```
 usage: plunger [-h] [--rpc-host RPC_HOST] [--rpc-port RPC_PORT]
-               [--gas-price GAS_PRICE] --source SOURCE
+               [--gas-price GAS_PRICE]
                (--list | --wait | --override-with-zero-txs)
                address
 
@@ -69,9 +69,6 @@ optional arguments:
   --rpc-port RPC_PORT   JSON-RPC port (default: `8545')
   --gas-price GAS_PRICE
                         Gas price (in Wei) for overriding transactions
-  --source SOURCE       Comma-separated list of sources to use for pending
-                        transaction discovery (available: etherscan,
-                        parity_txqueue)
   --list                List pending transactions
   --wait                Wait for the pending transactions to clear
   --override-with-zero-txs
@@ -84,7 +81,7 @@ If you want _plunger_ to only list pending transactions originating from the spe
 call it with the `--list` argument:
 
 ```bash
-bin/plunger --source etherscan,parity_txqueue --list 0x0101010101010101010101010101010101010101
+bin/plunger --list 0x0101010101010101010101010101010101010101
 ```
 
 ### Waiting for pending transactions to clear
@@ -93,7 +90,7 @@ If you want _plunger_ to just wait for the pending transactions from the specifi
 to get processed by the network (i.e. to get mined), run it with the `--wait` argument:
 
 ```bash
-bin/plunger --source etherscan,parity_txqueue --wait 0x0101010101010101010101010101010101010101
+bin/plunger --wait 0x0101010101010101010101010101010101010101
 ```
 
 This is a completely passive mode i.e. no Ethereum transactions get sent by _plunger_
@@ -109,7 +106,7 @@ If you want _plunger_ to try to override all pending transactions with a zero We
 but with gas cost higher than the original, run it with the `--override-with-zero-txs` argument:
 
 ```bash
-bin/plunger --source etherscan,parity_txqueue --override-with-zero-txs 0x0101010101010101010101010101010101010101
+bin/plunger --override-with-zero-txs 0x0101010101010101010101010101010101010101
 ```
 
 _Plunger_ will send replacement transactions immediately, then it will start monitoring the
@@ -139,15 +136,9 @@ as it is still possible the original one will go through.
 
 ### Pending transactions discovery
 
-The `--source` argument has to be used to specify how _plunger_ should discover pending transactions.
-Currently it can either query _etherscan.io_ (`--source etherscan`) or look for them in the Parity
-transaction queue (`--source parity_txqueue`). Bear in mind that it is a custom _Parity_ RPC endpoint
-and so this latter method will not work with _geth_.
-
-Both discovery methods can be used at the same time (`--source etherscan,parity_txqueue`).
-
-The _etherscan.io_ integration works by scraping their website as the API exposed by them
-does not give access to pending transactions.
+_Plunger_ discovers pending transactions by looking for them in the Parity transaction queue.
+Bear in mind that it is a custom _Parity_ RPC endpoint and so this latter method will not
+work with _geth_.
 
 
 ## Testing
@@ -171,7 +162,7 @@ export ETH_FROM=0x001.......
 seth send --async --gas-price=500000000 --value=1 -F $ETH_FROM $ETH_FROM
 seth send --async --gas-price=500000000 --value=1 -F $ETH_FROM $ETH_FROM
 
-bin/plunger --source parity_txqueue --override-with-zero-txs $ETH_FROM
+bin/plunger --override-with-zero-txs $ETH_FROM
 ```
 
 The above snippet uses `seth` (see <https://github.com/dapphub/seth>) for sending transactions.

--- a/plunger/plunger.py
+++ b/plunger/plunger.py
@@ -101,9 +101,9 @@ class Plunger:
 
     def override(self, transactions: list):
         # Override all pending transactions with zero-wei transfer transactions
+        gas_price = self.web3.eth.gasPrice if self.arguments.gas_price == 0 else self.arguments.gas_price
         for nonce in self.unique_nonces(transactions):
             try:
-                gas_price = self.web3.eth.gasPrice if self.arguments.gas_price == 0 else self.arguments.gas_price
                 tx_hash = self.web3.eth.sendTransaction({'from': self.web3.eth.defaultAccount,
                                                          'to': self.web3.eth.defaultAccount,
                                                          'gasPrice': gas_price,

--- a/tests/test_plunger.py
+++ b/tests/test_plunger.py
@@ -110,21 +110,11 @@ class TestPlunger:
         assert "usage: plunger" in err.getvalue()
         assert "error: the following arguments are required: address" in err.getvalue()
 
-    def test_should_complain_about_missing_source_when_only_address_specified(self):
+    def test_should_complain_about_missing_mode_when_only_address_specified(self):
         # when
         with captured_output() as (out, err):
             with pytest.raises(SystemExit):
                 Plunger(args("0x0000011111222223333322222111110000099999")).main()
-
-        # then
-        assert "usage: plunger" in err.getvalue()
-        assert "error: the following arguments are required: --source" in err.getvalue()
-
-    def test_should_complain_about_missing_mode_when_only_address_and_source_specified(self):
-        # when
-        with captured_output() as (out, err):
-            with pytest.raises(SystemExit):
-                Plunger(args("--source etherscan 0x0000011111222223333322222111110000099999")).main()
 
         # then
         assert "usage: plunger" in err.getvalue()
@@ -140,7 +130,7 @@ class TestPlunger:
             self.mock_0_pending_txs_in_parity_txqueue(mock, datadir, port_number)
 
             with captured_output() as (out, err):
-                Plunger(args(f"--rpc-port {port_number} --source parity_txqueue --list {some_account}")).main()
+                Plunger(args(f"--rpc-port {port_number} --list {some_account}")).main()
 
         # then
         assert out.getvalue() == f"There are no pending transactions on unknown from {some_account}\n"
@@ -155,7 +145,7 @@ class TestPlunger:
             self.mock_3_pending_txs_in_parity_txqueue(mock, datadir, port_number, some_account)
 
             with captured_output() as (out, err):
-                Plunger(args(f"--rpc-port {port_number} --source parity_txqueue --list {some_account}")).main()
+                Plunger(args(f"--rpc-port {port_number} --list {some_account}")).main()
 
         # then
         assert out.getvalue() == f"""There are 3 pending transactions on unknown from {some_account}:

--- a/tests/test_plunger.py
+++ b/tests/test_plunger.py
@@ -170,7 +170,7 @@ class TestPlunger:
 
     def test_should_ignore_pending_transactions_if_their_nonce_is_already_used(self, port_number, datadir):
         # given
-        web3 = Web3(TestRPCProvider("127.0.0.1", port_number))
+        web3 = Web3(TestRPCProvider("localhost", port_number))
         some_account = web3.eth.accounts[0]
 
         # and
@@ -178,17 +178,19 @@ class TestPlunger:
 
         # when
         with requests_mock.Mocker(real_http=True) as mock:
-            self.mock_3_pending_txs_on_eterscan(mock, datadir, some_account)
+            self.mock_3_pending_txs_in_parity_txqueue(mock, datadir, port_number, some_account)
 
             with captured_output() as (out, err):
-                Plunger(args(f"--rpc-port {port_number} --source etherscan --list {some_account}")).main()
+                Plunger(args(f"--rpc-port {port_number} --list {some_account}")).main()
 
         # then
-        assert out.getvalue() == f"""There is 1 pending transaction on unknown from {some_account}:
+        # Pending transaction with nonce 9 is ignored because last_nonce = 9
+        assert out.getvalue() == f"""There are 2 pending transactions on unknown from {some_account}:
 
                               TxHash                                 Nonce
 ==========================================================================
 0x124cb0887d0ea364b402fcc1369b7f9bf4d651bc77d2445aefbeab538dd3aab9      10
+0x53050e62c81fbe440d97d703860096467089bd37b2ad4cc6c699acf217436a64      11
 
 """
 

--- a/tests/test_plunger.py
+++ b/tests/test_plunger.py
@@ -132,7 +132,7 @@ class TestPlunger:
 
     def test_should_detect_0_pending_transactions_in_parity_txqueue(self, port_number, datadir):
         # given
-        web3 = Web3(TestRPCProvider("127.0.0.1", port_number))
+        web3 = Web3(TestRPCProvider("localhost", port_number))
         some_account = web3.eth.accounts[0]
 
         # when
@@ -147,7 +147,7 @@ class TestPlunger:
 
     def test_should_detect_3_pending_transactions_in_parity_txqueue(self, port_number, datadir):
         # given
-        web3 = Web3(TestRPCProvider("127.0.0.1", port_number))
+        web3 = Web3(TestRPCProvider("localhost", port_number))
         some_account = web3.eth.accounts[0]
 
         # when
@@ -198,7 +198,7 @@ class TestPlunger:
     def test_wait_should_not_terminate_until_transactions_get_mined(self, port_number, datadir):
         with captured_output() as (out, err):
             # given
-            web3 = Web3(TestRPCProvider("127.0.0.1", port_number))
+            web3 = Web3(TestRPCProvider("localhost", port_number))
             some_account = web3.eth.accounts[0]
 
             # when
@@ -243,7 +243,7 @@ All pending transactions have been mined.
     def test_should_override_transactions(self, port_number, datadir):
         with captured_output() as (out, err):
             # given
-            web3 = Web3(TestRPCProvider("127.0.0.1", port_number))
+            web3 = Web3(TestRPCProvider("localhost", port_number))
             web3.eth.defaultAccount = web3.eth.accounts[0]
             some_account = web3.eth.accounts[0]
 
@@ -280,7 +280,7 @@ All pending transactions have been mined.
     def test_should_use_custom_gas_price_when_overriding_transactions(self, port_number, datadir):
         with captured_output() as (out, err):
             # given
-            web3 = Web3(TestRPCProvider("127.0.0.1", port_number))
+            web3 = Web3(TestRPCProvider("localhost", port_number))
             web3.eth.defaultAccount = web3.eth.accounts[0]
             some_account = web3.eth.accounts[0]
             some_gas_price = 150000000


### PR DESCRIPTION
Support for Etherscan via `--source etherscan` has been very buggy and added complexity to the code. This PR removes Etherscan support and since Parity is the only possible source, the `--source` argument is dropped altogether.